### PR TITLE
feat: invert tracer color on hover

### DIFF
--- a/src/components/Tracker.astro
+++ b/src/components/Tracker.astro
@@ -10,9 +10,10 @@
     translate: -50% -50%;
     border-radius: 50%;
     background: hsl(var(--foreground));
-    z-index: 1;
+    z-index: 100;
     pointer-events: none;
     display: none;
+    mix-blend-mode: difference;
 
     @media screen and (min-width: 600px) {
       display: block;


### PR DESCRIPTION
Inverts the color when hovering over some text, also sets the z-index up to ensure it stays on top.

Looks like this (made it bigger to show off):
<img width="348" alt="Bildschirmfoto 2025-02-18 um 09 55 46" src="https://github.com/user-attachments/assets/b70735be-5d40-41e0-801b-db6a7f947bbb" />
